### PR TITLE
Handle changes which happen during compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   "dependencies": {
     "async": "^2.0.0",
     "debug": "^2.3.3",
-    "fb-watchman": "^1.9.0"
+    "fb-watchman": "^1.9.0",
+    "node-int64": "^0.4.0"
   },
   "ava": {
     "babel": "inherit"

--- a/src/WatchmanConnector.js
+++ b/src/WatchmanConnector.js
@@ -43,63 +43,24 @@ export default class WatchmanConnector extends EventEmitter {
    * `since` has to be either a string with a watchman clock value, or a number
    * which is then treated as a timestamp in milliseconds
    */
-  watch(files: Array<string>, dirs: Array<string>, since: string|number) {
+  watch(files: Array<string>, dirs: Array<string>, since: string|number, done?: () => void) {
     debug(`watch() called, current connection status: ${this.connected ? 'connected' : 'disconnected'}`);
     this.paused = false;
 
     if (this.connected) return;
 
     const allFiles = files.concat(dirs);
-    const client = this._getClientInstance();
 
-    client.capabilityCheck({ optional: [], required: ['cmd-watch-project', 'relative_root'] },
-      (capabilityErr) => {
-        /* istanbul ignore next: cannot happen in tests */
-        if (capabilityErr) throw capabilityErr;
-        debug('watchman capabilityCheck() successful');
-
-        // Initiate the watch
-        client.command(['watch-project', this.options.projectPath],
-          (watchError, watchResponse) => {
-            /* istanbul ignore next: cannot happen in tests */
-            if (watchError) throw watchError;
-            debug('watchman command watch-project successful');
-
-            /* istanbul ignore if: cannot happen in tests */
-            if (watchResponse.warning) {
-              console.warn('warning: ', watchResponse.warning); // eslint-disable-line no-console
-            }
-
-            const sub = {
-              expression: [
-                'allof',
-                [
-                  'name',
-                  allFiles.map(file => path.relative(this.options.projectPath, file)),
-                  'wholename',
-                ],
-              ],
-              fields: ['name', 'mtime_ms', 'exists'],
-              since: typeof since === 'string' ? since : new Int64(Math.floor(since / 1000)),
-              relative_root: watchResponse.relative_path,
-            };
-
-            client.on('subscription', this._onSubscription);
-
-            debug('watchman command subscription data: ', sub);
-
-            client.command(['subscribe', watchResponse.watch, 'webpack_subscription', sub],
-              (subscribeError) => {
-                /* istanbul ignore next: cannot happen in testsn */
-                if (subscribeError) throw subscribeError;
-                debug('watchman command subscribe successful');
-              });
-          },
-        );
-      },
-    );
-
-    this._doInitialScan(allFiles);
+    Promise.all([
+      new Promise((resolve, reject) => {
+        this._startWatch(allFiles, since, err => (err ? reject(err) : resolve()));
+      }),
+      new Promise((resolve) => {
+        this._doInitialScan(allFiles, resolve);
+      }),
+    ])
+      .catch((err) => { throw err; })
+      .then(() => (done ? done() : null));
   }
 
   getTimes(): { [key: string]: number } {
@@ -125,6 +86,67 @@ export default class WatchmanConnector extends EventEmitter {
     debug('pause() called');
     this.paused = true;
     if (this.timeoutRef) clearTimeout(this.timeoutRef);
+  }
+
+  _startWatch(files: Array<string>, since: string|number, done: () => void): void {
+    const client = this._getClientInstance();
+
+    client.capabilityCheck({ optional: [], required: ['cmd-watch-project', 'relative_root'] },
+      (capabilityErr) => {
+        /* istanbul ignore if: cannot happen in tests */
+        if (capabilityErr) {
+          done(capabilityErr);
+          return;
+        }
+        debug('watchman capabilityCheck() successful');
+
+        // Initiate the watch
+        client.command(['watch-project', this.options.projectPath],
+          (watchError, watchResponse) => {
+            /* istanbul ignore if: cannot happen in tests */
+            if (watchError) {
+              done(watchError);
+              return;
+            }
+            debug('watchman command watch-project successful');
+
+            /* istanbul ignore if: cannot happen in tests */
+            if (watchResponse.warning) {
+              console.warn('warning: ', watchResponse.warning); // eslint-disable-line no-console
+            }
+
+            const sub = {
+              expression: [
+                'allof',
+                [
+                  'name',
+                  files.map(file => path.relative(this.options.projectPath, file)),
+                  'wholename',
+                ],
+              ],
+              fields: ['name', 'mtime_ms', 'exists'],
+              since: typeof since === 'string' ? since : new Int64(Math.floor(since / 1000)),
+              relative_root: watchResponse.relative_path,
+            };
+
+            client.on('subscription', this._onSubscription);
+
+            debug('watchman command subscription data: ', sub);
+
+            client.command(['subscribe', watchResponse.watch, 'webpack_subscription', sub],
+              (subscribeError) => {
+                /* istanbul ignore if: cannot happen in testsn */
+                if (subscribeError) {
+                  done(subscribeError);
+                  return;
+                }
+                debug('watchman command subscribe successful');
+                done();
+              });
+          },
+        );
+      },
+    );
   }
 
   _onSubscription = (resp: WatchmanResponse): void => {
@@ -193,7 +215,7 @@ export default class WatchmanConnector extends EventEmitter {
     this.emit('aggregated', changes, this.lastClock);
   };
 
-  _doInitialScan(files: Array<string>): void {
+  _doInitialScan(files: Array<string>, done: () => void): void {
     debug('starting initial file scan');
     async.eachLimit(files, 500, (file, callback) => {
       fs.stat(file, (err, stat) => {
@@ -223,6 +245,7 @@ export default class WatchmanConnector extends EventEmitter {
       }
 
       this.initialScanQueue.clear();
+      done();
     });
   }
 }

--- a/src/WatchmanConnector.js
+++ b/src/WatchmanConnector.js
@@ -1,10 +1,11 @@
 /* @flow */
+import async from 'async';
 import createDebug from 'debug';
 import EventEmitter from 'events';
+import { Client } from 'fb-watchman';
+import Int64 from 'node-int64';
 import fs from 'fs';
 import path from 'path';
-import { Client } from 'fb-watchman';
-import async from 'async';
 import fsAccurency from './utils/fsAccurency';
 
 const debug = createDebug('watchman:connector');
@@ -12,6 +13,7 @@ const debug = createDebug('watchman:connector');
 type Options = { aggregateTimeout: number, projectPath: string};
 
 type WatchmanResponse = {
+  clock: string,
   subscription: string,
   files: Array<{ name: string, mtime_ms: number, 'new': boolean, exists: boolean }>
 };
@@ -21,6 +23,7 @@ export default class WatchmanConnector extends EventEmitter {
   aggregatedChanges: Array<string> = [];
   client: ?Client;
   connected: boolean = false;
+  lastClock: string;
   fileTimes: Object = {};
   options: Options;
   paused: boolean = true;
@@ -36,7 +39,11 @@ export default class WatchmanConnector extends EventEmitter {
     this.options = options;
   }
 
-  watch(files: Array<string>, dirs: Array<string>) {
+  /**
+   * `since` has to be either a string with a watchman clock value, or a number
+   * which is then treated as a timestamp in milliseconds
+   */
+  watch(files: Array<string>, dirs: Array<string>, since: string|number) {
     debug(`watch() called, current connection status: ${this.connected ? 'connected' : 'disconnected'}`);
     this.paused = false;
 
@@ -57,36 +64,32 @@ export default class WatchmanConnector extends EventEmitter {
             debug('watchman command watch-project successful');
 
             if (watchResponse.warning) {
-              console.log('warning: ', watchResponse.warning); // eslint-disable-line no-console
+              console.warn('warning: ', watchResponse.warning); // eslint-disable-line no-console
             }
 
-            client.command(['clock', watchResponse.watch], (clockError, clockResponse) => {
-              if (clockError) throw clockError;
-
-              const sub = {
-                expression: [
-                  'allof',
-                  [
-                    'name',
-                    allFiles.map(file => path.relative(this.options.projectPath, file)),
-                    'wholename',
-                  ],
+            const sub = {
+              expression: [
+                'allof',
+                [
+                  'name',
+                  allFiles.map(file => path.relative(this.options.projectPath, file)),
+                  'wholename',
                 ],
-                fields: ['name', 'mtime_ms', 'exists'],
-                since: clockResponse.clock,
-                relative_root: watchResponse.relative_path,
-              };
+              ],
+              fields: ['name', 'mtime_ms', 'exists'],
+              since: typeof since === 'string' ? since : new Int64(Math.floor(since / 1000)),
+              relative_root: watchResponse.relative_path,
+            };
 
-              debug('watchman command subscription data: ', sub);
+            client.on('subscription', this._onSubscription);
 
-              client.on('subscription', this._onSubscription);
+            debug('watchman command subscription data: ', sub);
 
-              client.command(['subscribe', watchResponse.watch, 'webpack_subscription', sub],
-                (subscribeError) => {
-                  if (subscribeError) throw subscribeError;
-                  debug('watchman command subscribe successful');
-                });
-            });
+            client.command(['subscribe', watchResponse.watch, 'webpack_subscription', sub],
+              (subscribeError) => {
+                if (subscribeError) throw subscribeError;
+                debug('watchman command subscribe successful');
+              });
           },
         );
       },
@@ -123,6 +126,7 @@ export default class WatchmanConnector extends EventEmitter {
   _onSubscription = (resp: WatchmanResponse): void => {
     debug('received subscription: %O', resp);
     if (resp.subscription === 'webpack_subscription') {
+      this.lastClock = resp.clock;
       resp.files.forEach((file) => {
         const filePath = path.join(this.options.projectPath, file.name);
         const mtime = (!file.exists) ? null : +file.mtime_ms;
@@ -182,7 +186,7 @@ export default class WatchmanConnector extends EventEmitter {
     const changes = this.aggregatedChanges;
     this.aggregatedChanges = [];
 
-    this.emit('aggregated', changes);
+    this.emit('aggregated', changes, this.lastClock);
   };
 
   _doInitialScan(files: Array<string>): void {

--- a/src/WatchmanConnector.js
+++ b/src/WatchmanConnector.js
@@ -54,15 +54,18 @@ export default class WatchmanConnector extends EventEmitter {
 
     client.capabilityCheck({ optional: [], required: ['cmd-watch-project', 'relative_root'] },
       (capabilityErr) => {
+        /* istanbul ignore next: cannot happen in tests */
         if (capabilityErr) throw capabilityErr;
         debug('watchman capabilityCheck() successful');
 
         // Initiate the watch
         client.command(['watch-project', this.options.projectPath],
           (watchError, watchResponse) => {
+            /* istanbul ignore next: cannot happen in tests */
             if (watchError) throw watchError;
             debug('watchman command watch-project successful');
 
+            /* istanbul ignore if: cannot happen in tests */
             if (watchResponse.warning) {
               console.warn('warning: ', watchResponse.warning); // eslint-disable-line no-console
             }
@@ -87,6 +90,7 @@ export default class WatchmanConnector extends EventEmitter {
 
             client.command(['subscribe', watchResponse.watch, 'webpack_subscription', sub],
               (subscribeError) => {
+                /* istanbul ignore next: cannot happen in testsn */
                 if (subscribeError) throw subscribeError;
                 debug('watchman command subscribe successful');
               });

--- a/src/WatchmanWatchFileSystem.js
+++ b/src/WatchmanWatchFileSystem.js
@@ -19,6 +19,7 @@ export default class WatchmanWatchFileSystem {
   inputFileSystem: Object;
   options: Options;
   watcher: Watchman;
+  lastClock: string;
 
   constructor(inputFileSystem: Object, options: Options): void {
     this.inputFileSystem = inputFileSystem;
@@ -46,7 +47,8 @@ export default class WatchmanWatchFileSystem {
       });
     }
 
-    this.watcher.once('aggregated', (changes) => {
+    this.watcher.once('aggregated', (changes, clock) => {
+      this.lastClock = clock;
       debug('aggregated event received with changes: ', changes);
       if (this.inputFileSystem && this.inputFileSystem.purge) {
         this.inputFileSystem.purge(changes);
@@ -64,7 +66,7 @@ export default class WatchmanWatchFileSystem {
       );
     });
 
-    this.watcher.watch(files.concat(missing), dirs, startTime);
+    this.watcher.watch(files.concat(missing), dirs, this.lastClock || startTime);
 
     if (oldWatcher) {
       debug('closing old connector');

--- a/test/WatchmanConnector.js
+++ b/test/WatchmanConnector.js
@@ -20,6 +20,10 @@ test.cb.afterEach((t) => {
   t.context.testHelper.after(t.end);
 });
 
+test('can be closed without prior start', (t) => {
+  t.notThrows(() => t.context.connector.close());
+});
+
 test('checks for options', (t) => {
   t.throws(() => new WatchmanConnector(), 'projectPath is missing for WatchmanPlugin');
 });
@@ -31,14 +35,14 @@ test.cb('change is emitted for changed file', (t) => {
   const filePath = path.join(cwd, filename);
 
   testHelper.file(filename, () => {
-    connector.watch([filePath], []);
+    connector.watch([filePath], [], Date.now() + 1000);
     connector.on('change', (file, mtime) => {
       t.is(file, filePath);
       t.true(typeof mtime === 'number');
       t.end();
     });
 
-    TestHelper.tick(() => testHelper.mtime(filename, Date.now()));
+    TestHelper.tick(() => testHelper.mtime(filename, Date.now()), 1500);
   });
 });
 
@@ -48,13 +52,13 @@ test.cb('aggregated is emitted', (t) => {
   const filename = TestHelper.generateFilename();
   const filePath = path.join(cwd, filename);
 
-  connector.watch([filePath], []);
+  connector.watch([filePath], [], Date.now() + 1000);
   connector.on('aggregated', (files) => {
     t.deepEqual(files, [filePath]);
     t.end();
   });
 
-  TestHelper.tick(() => testHelper.file(filename));
+  TestHelper.tick(() => testHelper.file(filename), 1500);
 });
 
 test.cb('change is not emitted during initialScan', (t) => {
@@ -63,7 +67,7 @@ test.cb('change is not emitted during initialScan', (t) => {
   const filename = TestHelper.generateFilename();
   const filePath = path.join(cwd, filename);
 
-  connector.watch([filePath], []);
+  connector.watch([filePath], [], Date.now() + 1000);
   connector.on('change', () => t.fail('Should not trigger change'));
 
   TestHelper.tick(() => {

--- a/test/WatchmanConnector.js
+++ b/test/WatchmanConnector.js
@@ -81,7 +81,7 @@ test.cb('change is not emitted during initialScan', (t) => {
   });
 });
 
-test.cb('change during compilation is correctly emitted', (t) => {
+test.cb('change before starting watch is correctly emitted', (t) => {
   t.plan(2);
   const { connector, cwd, testHelper } = t.context;
   const oldDate = Date.now();

--- a/test/WatchmanConnector.js
+++ b/test/WatchmanConnector.js
@@ -79,7 +79,7 @@ test.cb('change is not emitted during initialScan', (t) => {
       TestHelper.tick(() => {
         t.is(connector.initialScanQueue.size, 1);
         t.end();
-      }, 2000);
+      });
     });
   });
 });

--- a/test/WatchmanConnector.js
+++ b/test/WatchmanConnector.js
@@ -80,3 +80,21 @@ test.cb('change is not emitted during initialScan', (t) => {
     });
   });
 });
+
+test.cb('change during compilation is correctly emitted', (t) => {
+  t.plan(2);
+  const { connector, cwd, testHelper } = t.context;
+  const oldDate = Date.now();
+  const filename = TestHelper.generateFilename();
+  const filePath = path.join(cwd, filename);
+
+  connector.on('change', (file, mtime) => {
+    t.is(file, filePath);
+    t.true(typeof mtime === 'number');
+    t.end();
+  });
+
+  testHelper.file(filename, () => {
+    connector.watch([filePath], [], oldDate);
+  });
+});


### PR DESCRIPTION
Initially we use the timestamp that webpack provides to tell watchman to watch since this time.
Afterwards we always keep the last clock value of subscription result, which is more accurate.

node-int64 is a dependency now due to bug facebook/watchman#393

Fixes #11

Tests are missing